### PR TITLE
docs: Update installation command in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Parse ARP file from `/proc/net/arp`
 
 ## Install
 ```shell
-go get -u github.com/itsjimi/go-arp
+go get -u github.com/ItsJimi/go-arp
 ```
 
 ## Example


### PR DESCRIPTION
## Problem

The command `go get -u github.com/itsjimi/go-arp` doesn't work and return:
```shell
go: downloading github.com/itsjimi/go-arp v0.0.0-20201012204938-e64e09dca888
go: github.com/itsjimi/go-arp@upgrade (v0.0.0-20201012204938-e64e09dca888) requires github.com/itsjimi/go-arp@v0.0.0-20201012204938-e64e09dca888: parsing go.mod:
        module declares its path as: github.com/ItsJimi/go-arp
                but was required as: github.com/itsjimi/go-arp
```

## Solution

Use `go get -u github.com/ItsJimi/go-arp`